### PR TITLE
Use Resolver.mavenLocal instead of full path

### DIFF
--- a/documentation/manual/detailedTopics/build/SBTDependencies.md
+++ b/documentation/manual/detailedTopics/build/SBTDependencies.md
@@ -73,8 +73,6 @@ resolvers += "sonatype snapshots" at "https://oss.sonatype.org/content/repositor
 sbt can search your local Maven repository if you add it as a repository:
 
 ```scala
-resolvers += (
-    "Local Maven Repository" at "file:///"+Path.userHome.absolutePath+"/.m2/repository"
-)
+resolvers += Resolver.mavenLocal
 ```
 


### PR DESCRIPTION
I just discovered about `Resolver.mavenLocal`and thought it would be a better idea to use it in the document rather than building the full path to the local reposotory.
